### PR TITLE
Use npm ci when building

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -6,6 +6,6 @@ route = ""
 workers_dev = true
 
 [build]
-command = "npm install && npm run build"
+command = "npm ci && npm run build"
 [build.upload]
 format = "service-worker"


### PR DESCRIPTION
This ensures that the dependencies installed upon a build will be same ones as defined in `package-lock.json`. Using `npm install` could result in different-than-expected dependencies, which makes things hander to debug and/or pulling in potential breaking changes.